### PR TITLE
fix: remove compromised polyfill.io script

### DIFF
--- a/layouts/partials/mathjax_support.html
+++ b/layouts/partials/mathjax_support.html
@@ -17,6 +17,5 @@
     });
 
 </script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script type="text/javascript" id="MathJax-script" async
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
The polyfill.io domain was taken over in a supply chain attack (2024) and now serves malicious content including phishing sign-in forms.

MathJax 3 does not require ES6 polyfills since all modern browsers already support ES6 natively. Simply removing the script tag fixes the exploit with no loss of functionality.