### PR TITLE
Add Students section to homepage

### DIFF
--- a/data/en/sections/students.yaml
+++ b/data/en/sections/students.yaml
@@ -1,0 +1,105 @@
+# section information
+section:
+  name: Students
+  id: students
+  enable: true
+  weight: 4
+  showOnNavbar: true
+  # Can optionally hide the title in sections
+  # hideTitle: true
+
+# current students
+students:
+- name: Roger Creus-Castanyer
+  program: PhD
+  university: Université de Montréal
+  principal_supervisor: Glen Berseth
+  website: https://roger-creus.github.io/
+  github: https://github.com/roger-creus
+  scholar: https://scholar.google.com/citations?view_op=list_works&hl=en&user=E3y_txsAAAAJ
+  papers:
+  - name: "ARM-FM: Automated Reward Machines via Foundation Models"
+    url: https://openreview.net/forum?id=OBpQdCWLfd
+  - name: "Stable Gradients for Stable Learning at Scale in Deep RL"
+    url: https://openreview.net/forum?id=Vqj65VeDOu
+
+- name: Julian Dierkes
+  program: Independent Visiting Researcher
+  university: RWTH Aachen University
+  website: https://labchameleon.github.io
+  github: https://github.com/LabChameleon
+  scholar: https://scholar.google.com/citations?user=dYzkTPEAAAAJ&hl=en
+
+- name: Nicola Gauthier
+  program: Master's Research
+  university: Université de Montréal
+
+- name: Olya Mastikhina
+  program: PhD
+  university: Université de Montréal
+  papers:
+  - name: "Optimistic critics can empower small actors"
+    url: https://openreview.net/forum?id=yx68Ns2e5E
+
+- name: Walter Mayor
+  program: Collaborating Researcher
+  website: https://waltermayor.github.io/
+  github: https://github.com/waltermayor
+  scholar: https://scholar.google.com/citations?hl=en&user=fGTJwC4AAAAJ
+  papers:
+  - name: "Simplicial Embeddings Improve Sample Efficiency in Actor-Critic Agents"
+    url: https://openreview.net/forum?id=mCpq1GCKxA
+  - name: "The Impact of On-Policy Parallelized Data Collection on Deep RL Networks"
+    url: https://openreview.net/forum?id=cnqyzuZhSo
+
+- name: Johan Samir Obando-Ceron
+  program: PhD
+  university: Université de Montréal
+  principal_supervisor: Aaron Courville
+  website: https://johanobandoc.github.io
+  github: https://github.com/JohanSamir
+  scholar: https://scholar.google.com/citations?hl=es&user=KViAb3EAAAAJ
+  papers:
+  - name: "Simplicial Embeddings Improve Sample Efficiency in Actor-Critic Agents"
+    url: https://openreview.net/forum?id=mCpq1GCKxA
+  - name: "Stable Deep RL via Isotropic Gaussian Representations"
+    url: https://openreview.net/forum?id=gc7Gg18ejz
+  - name: "Stable Gradients for Stable Learning at Scale in Deep RL"
+    url: https://openreview.net/forum?id=Vqj65VeDOu
+  - name: "Mind the GAP! Challenges of Scale in Pixel-based Deep RL"
+    url: https://openreview.net/forum?id=LrBWGwVfCA
+  - name: "In value-based deep RL, a pruned network is a good network"
+    url: https://arxiv.org/abs/2402.12479
+  - name: "Mixtures of experts unlock parameter scaling for deep RL"
+    url: https://arxiv.org/abs/2402.08609
+  - name: "On the consistency of hyper-parameter selection in value-based deep RL"
+    url: https://arxiv.org/abs/2406.17523
+  - name: "Small batch deep reinforcement learning"
+    url: https://proceedings.neurips.cc/paper_files/paper/2023/hash/528388f1ad3a481249a97cbb698d2fe6-Abstract-Conference.html
+  - name: "Revisiting Rainbow"
+    url: https://arxiv.org/abs/2011.14826
+
+- name: Gandharv Patil
+  program: PhD
+  university: McGill University
+  principal_supervisor: Doina Precup
+  website: https://www.gandharvpatil.com
+  github: https://github.com/gp1702
+  scholar: https://scholar.google.com/citations?user=onD9-zcAAAAJ&hl=en
+
+- name: Ali Saheb Pasand
+  program: PhD
+  university: McGill University
+  principal_supervisor: Blake Richards
+  papers:
+  - name: "Stable Deep RL via Isotropic Gaussian Representations"
+    url: https://openreview.net/forum?id=gc7Gg18ejz
+
+- name: Dhruv Sreenivas
+  program: PhD
+  university: Université de Montréal
+  website: https://dhruvsreenivas.github.io
+  github: https://github.com/dhruvsreenivas
+  papers:
+  - name: "Optimistic critics can empower small actors"
+    url: https://openreview.net/forum?id=yx68Ns2e5E

--- a/layouts/partials/sections/students.html
+++ b/layouts/partials/sections/students.html
@@ -1,0 +1,65 @@
+{{ $sectionID := replace (lower .section.name) " " "-"  }}
+{{ if .section.id }}
+  {{ $sectionID = .section.id }}
+{{ end }}
+
+<div class="container-fluid anchor pb-5 students-section" id="{{ $sectionID }}">
+  {{ if not (.section.hideTitle) }}
+    <h1 class="text-center">{{ .section.name }}</h1>
+  {{ end }}
+  <div class="container">
+    <div class="text-center mb-4">
+      <p>These are my current students. For more details, see my
+        <a href="https://mila.quebec/en/directory/pablo-samuel-castro" target="_blank">Mila directory page</a>.
+      </p>
+    </div>
+    <div class="row justify-content-center">
+      {{ range .students }}
+      <div class="col-md-6 col-lg-4 mb-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body">
+            <h5 class="card-title">{{ .name }}</h5>
+            <p class="card-text mb-1">
+              <strong>{{ .program }}</strong>
+              {{ with .university }}
+                <br><em>{{ . }}</em>
+              {{ end }}
+              {{ with .principal_supervisor }}
+                <br><small class="text-muted">Principal supervisor: {{ . }}</small>
+              {{ end }}
+            </p>
+            <div class="mt-2 mb-2">
+              {{ with .website }}
+                <a href="{{ . }}" target="_blank" class="btn btn-sm btn-outline-primary mr-1 mb-1">
+                  <i class="fas fa-globe"></i> Website
+                </a>
+              {{ end }}
+              {{ with .github }}
+                <a href="{{ . }}" target="_blank" class="btn btn-sm btn-outline-dark mr-1 mb-1">
+                  <i class="fab fa-github"></i> GitHub
+                </a>
+              {{ end }}
+              {{ with .scholar }}
+                <a href="{{ . }}" target="_blank" class="btn btn-sm btn-outline-info mr-1 mb-1">
+                  <i class="fas fa-graduation-cap"></i> Scholar
+                </a>
+              {{ end }}
+            </div>
+            {{ with .papers }}
+              <hr>
+              <h6 class="card-subtitle mb-2 text-muted">Papers together:</h6>
+              <ul class="list-unstyled small">
+                {{ range . }}
+                  <li class="mb-1">
+                    <a href="{{ .url }}" target="_blank">📄 {{ .name }}</a>
+                  </li>
+                {{ end }}
+              </ul>
+            {{ end }}
+          </div>
+        </div>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
New section listing current students with:
- Name, program, university, and principal supervisor
- Links to website, GitHub, and Google Scholar
- Links to co-authored papers from the publications list

Student data sourced from Mila directory page. The section automatically appears in the top navbar via the Toha theme's section system (weight: 4, after publications).