### PR TITLE
Add Johan Obando-Ceron (Master's) to Past Students

### DIFF
--- a/data/en/sections/past-students.yaml
+++ b/data/en/sections/past-students.yaml
@@ -13,3 +13,15 @@ students:
   papers:
   - name: "A Survey of State Representation Learning for Deep Reinforcement Learning"
     url: https://openreview.net/forum?id=gOk34vUHtz
+
+- name: Johan Samir Obando-Ceron
+  program: Master's
+  university: Université de Montréal
+  website: https://johanobandoc.github.io
+  github: https://github.com/JohanSamir
+  scholar: https://scholar.google.com/citations?hl=es&user=KViAb3EAAAAJ
+  papers:
+  - name: "Revisiting Rainbow"
+    url: https://arxiv.org/abs/2011.14826
+  - name: "Small batch deep reinforcement learning"
+    url: https://proceedings.neurips.cc/paper_files/paper/2023/hash/528388f1ad3a481249a97cbb698d2fe6-Abstract-Conference.html

--- a/data/en/sections/students.yaml
+++ b/data/en/sections/students.yaml
@@ -74,10 +74,6 @@ students:
     url: https://arxiv.org/abs/2402.08609
   - name: "On the consistency of hyper-parameter selection in value-based deep RL"
     url: https://arxiv.org/abs/2406.17523
-  - name: "Small batch deep reinforcement learning"
-    url: https://proceedings.neurips.cc/paper_files/paper/2023/hash/528388f1ad3a481249a97cbb698d2fe6-Abstract-Conference.html
-  - name: "Revisiting Rainbow"
-    url: https://arxiv.org/abs/2011.14826
 
 - name: Gandharv Patil
   program: PhD


### PR DESCRIPTION
Move 'Revisiting Rainbow' and 'Small batch deep reinforcement learning' from his PhD card to his new Master's card in Past Students, since those papers are from his Master's period.